### PR TITLE
feat: add cache fallbacks, allow multiple prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,23 +43,29 @@ It would reduce time of docker build.
 
 ### `pull_request` event
 
-When a pull request is opened, this action instructs docker/build-push-action to import cache of the base branch.
+When a pull request is opened, this action instructs docker/build-push-action to import cache of the pull request branch with a fallback to the base branch and the default branch.
 It does not export cache to prevent cache pollution.
 For example,
 
 ```yaml
-cache-from: type=registry,ref=IMAGE:main
+cache-from: |
+  type=registry,ref=IMAGE:head
+  type=registry,ref=IMAGE:base
+  type=registry,ref=IMAGE:main
 cache-to:
 ```
 
 ### `push` event of branch
 
-When a branch is pushed, this action instructs docker/build-push-action to import and export cache of the branch.
+When a branch is pushed, this action instructs docker/build-push-action to import and export cache of the branch with a fallback to the default branch.
 For example,
 
 ```yaml
-cache-from: type=registry,ref=IMAGE:main
-cache-to: type=registry,ref=IMAGE:main,mode=max
+cache-from: |
+  type=registry,ref=IMAGE:head
+  type=registry,ref=IMAGE:main
+cache-to: |
+  type=registry,ref=IMAGE:main,mode=max
 ```
 
 ### `push` event of tag
@@ -69,18 +75,21 @@ It does not export cache to prevent cache pollution.
 For example,
 
 ```yaml
-cache-from: type=registry,ref=IMAGE:main
+cache-from: |
+  type=registry,ref=IMAGE:main
 cache-to:
 ```
 
 ### Others
 
-Otherwise, this action instructs docker/build-push-action to import cache of the triggered branch.
+Otherwise, this action instructs docker/build-push-action to import cache of the triggered branch with a fallback to the default branch.
 It does not export cache to prevent cache pollution.
 For example,
 
 ```yaml
-cache-from: type=registry,ref=IMAGE:main
+cache-from: |
+  type=registry,ref=IMAGE:head
+  type=registry,ref=IMAGE:main
 cache-to:
 ```
 
@@ -121,7 +130,8 @@ You can set a tag prefix to isolate caches.
         id: cache
         with:
           image: ghcr.io/${{ github.repository }}/cache
-          tag-prefix: microservice-name--
+          tag-prefix: |
+            microservice-name--
       - uses: docker/build-push-action@v2
         id: build
         with:
@@ -138,7 +148,7 @@ You can set a tag prefix to isolate caches.
 | Name | Default | Description
 |------|----------|------------
 | `image` | (required) | Image name to import/export cache
-| `tag-prefix` | ` ` | Prefix of tag
+| `tag-prefix` | `[]` | An array of tag prefixes
 
 
 ## Outputs

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -53,7 +53,7 @@ export const infer = (context: PartialContext, inputs: Inputs): Cache => {
   }
 }
 
-const escape = (s: string) => s.replace(/[/]/, '-')
+const escape = (s: string) => s.replaceAll(/[^\w.-]/g, '-')
 
 const inferBranch = (context: PartialContext): Cache => {
   if (context.eventName === 'pull_request') {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -28,6 +28,13 @@ export const infer = (context: PartialContext, inputs: Inputs): Cache => {
     from.push(`${inputs.image}:${escape(`${bFrom}`)}`)
   }
 
+  for (const prefix of inputs.tagPrefix) {
+    const fromDefaultPrefixed = `${inputs.image}:${escape(
+      `${prefix}${(context.payload as PullRequestEvent | PushEvent).repository.default_branch}`
+    )}`
+    from.push(fromDefaultPrefixed)
+  }
+
   const fromDefault = `${inputs.image}:${escape(
     (context.payload as PullRequestEvent | PushEvent).repository.default_branch
   )}`
@@ -41,7 +48,7 @@ export const infer = (context: PartialContext, inputs: Inputs): Cache => {
   }
 
   return {
-    from,
+    from: [...new Set(from)],
     to,
   }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -83,6 +83,17 @@ const inferBranch = (context: PartialContext): Cache => {
     }
   }
 
+
+  if (context.eventName === 'release') {
+    if (context.ref.startsWith('refs/tags/')) {
+      // tag push
+      return {
+        from: [],
+        to: [],
+      }
+    }
+  }
+
   return {
     from: [trimPrefix(context.ref, 'refs/heads/')],
     to: [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { run } from './run'
 const main = (): void => {
   const outputs = run({
     image: core.getInput('image', { required: true }),
-    tagPrefix: core.getInput('tag-prefix'),
+    tagPrefix: core.getInput('tag-prefix').split('\n'),
   })
   core.setOutput('cache-from', outputs.cacheFrom)
   core.setOutput('cache-to', outputs.cacheTo)

--- a/src/run.ts
+++ b/src/run.ts
@@ -11,10 +11,10 @@ type Outputs = {
 
 export const run = (inputs: Inputs): Outputs => {
   const c = cache.infer(github.context, inputs)
-  core.info(`Inferred cache: from=${c.from.join(', ')}, to=${c.to ?? 'null'}`)
+  core.info(`Inferred cache: from=${c.from.join('|')}, to=${c.to.join('|')}`)
 
   return {
     cacheFrom: c.from.map((from) => `type=registry,ref=${from}`).join('\n'),
-    cacheTo: c.to !== null ? `type=registry,ref=${c.to},mode=max` : '',
+    cacheTo: c.to.map((to) => `type=registry,ref=${to},mode=max`).join('\n'),
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -14,7 +14,7 @@ export const run = (inputs: Inputs): Outputs => {
   core.info(`Inferred cache: from=${c.from.join(', ')}, to=${c.to ?? 'null'}`)
 
   return {
-    cacheFrom: '|' + c.from.map((from) => `\n  type=registry,ref=${from}`).join(),
+    cacheFrom: c.from.map((from) => `type=registry,ref=${from}`).join('\n'),
     cacheTo: c.to !== null ? `type=registry,ref=${c.to},mode=max` : '',
   }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -11,10 +11,10 @@ type Outputs = {
 
 export const run = (inputs: Inputs): Outputs => {
   const c = cache.infer(github.context, inputs)
-  core.info(`Inferred cache: from=${c.from}, to=${c.to ?? 'null'}`)
+  core.info(`Inferred cache: from=${c.from.join(', ')}, to=${c.to ?? 'null'}`)
 
   return {
-    cacheFrom: `type=registry,ref=${c.from}`,
+    cacheFrom: '|' + c.from.map((from) => `\n  type=registry,ref=${from}`).join(),
     cacheTo: c.to !== null ? `type=registry,ref=${c.to},mode=max` : '',
   }
 }

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,5 +1,54 @@
 import * as cache from '../src/cache'
 
+const payloadRepository = {
+  repository: {
+    default_branch: 'main',
+    name: 'sandbox',
+    owner: { login: 'int128' },
+  },
+}
+
+const eventPullRequest = {
+  eventName: 'pull_request',
+  ref: 'refs/pulls/123/merge',
+  payload: {
+    pull_request: {
+      number: 123,
+      base: {
+        ref: 'main',
+      },
+      head: {
+        ref: 'feature',
+      },
+    },
+    ...payloadRepository,
+  },
+}
+
+const eventPushBranch = {
+  eventName: 'push',
+  ref: 'refs/heads/feature',
+  payload: {
+    ...payloadRepository,
+  },
+}
+
+const eventPushTag = {
+  eventName: 'push',
+  ref: 'refs/tags/v1.0.0',
+  payload: {
+    ...payloadRepository,
+  },
+}
+
+const eventSchedule = {
+  eventName: 'schedule',
+  ref: 'refs/heads/schedule',
+  payload: {
+    ...payloadRepository,
+  },
+}
+
 const inputs = {
   image: 'ghcr.io/int128/sandbox/cache',
   tagPrefix: '',
@@ -11,94 +60,48 @@ const inputsPrefixed = {
 }
 
 test('on pull request', () => {
-  const c = cache.infer(
-    {
-      eventName: 'pull_request',
-      ref: 'refs/pulls/123/merge',
-      payload: {
-        pull_request: {
-          number: 123,
-          base: {
-            ref: 'main',
-          },
-        },
-      },
-    },
-    inputs
-  )
+  const c = cache.infer(eventPullRequest, inputs)
   expect(c).toStrictEqual({
-    from: ['ghcr.io/int128/sandbox/cache:main'],
+    from: ['ghcr.io/int128/sandbox/cache:feature', 'ghcr.io/int128/sandbox/cache:main'],
     to: null,
   })
 })
 
 test('on pull request with prefix', () => {
-  const c = cache.infer(
-    {
-      eventName: 'pull_request',
-      ref: 'refs/pulls/123/merge',
-      payload: {
-        pull_request: {
-          number: 123,
-          base: {
-            ref: 'main',
-          },
-        },
-      },
-    },
-    inputsPrefixed
-  )
+  const c = cache.infer(eventPullRequest, inputsPrefixed)
   expect(c).toStrictEqual({
-    from: ['ghcr.io/int128/sandbox/cache:prefix-main', 'ghcr.io/int128/sandbox/cache:main'],
+    from: [
+      'ghcr.io/int128/sandbox/cache:prefix-feature',
+      'ghcr.io/int128/sandbox/cache:prefix-main',
+      'ghcr.io/int128/sandbox/cache:feature',
+      'ghcr.io/int128/sandbox/cache:main',
+    ],
     to: null,
   })
 })
 
 test('on push branch', () => {
-  const c = cache.infer(
-    {
-      eventName: 'push',
-      ref: 'refs/heads/main',
-      payload: {},
-    },
-    inputs
-  )
+  const c = cache.infer(eventPushBranch, inputs)
   expect(c).toStrictEqual({
-    from: ['ghcr.io/int128/sandbox/cache:main'],
-    to: 'ghcr.io/int128/sandbox/cache:main',
+    from: ['ghcr.io/int128/sandbox/cache:feature', 'ghcr.io/int128/sandbox/cache:main'],
+    to: 'ghcr.io/int128/sandbox/cache:feature',
   })
 })
 
 test('on push branch with prefix', () => {
-  const c = cache.infer(
-    {
-      eventName: 'push',
-      ref: 'refs/heads/main',
-      payload: {},
-    },
-    inputsPrefixed
-  )
+  const c = cache.infer(eventPushBranch, inputsPrefixed)
   expect(c).toStrictEqual({
-    from: ['ghcr.io/int128/sandbox/cache:prefix-main', 'ghcr.io/int128/sandbox/cache:main'],
-    to: 'ghcr.io/int128/sandbox/cache:prefix-main',
+    from: [
+      'ghcr.io/int128/sandbox/cache:prefix-feature',
+      'ghcr.io/int128/sandbox/cache:feature',
+      'ghcr.io/int128/sandbox/cache:main',
+    ],
+    to: 'ghcr.io/int128/sandbox/cache:prefix-feature',
   })
 })
 
 test('on push tag', () => {
-  const c = cache.infer(
-    {
-      eventName: 'push',
-      ref: 'refs/tags/v1.0.0',
-      payload: {
-        repository: {
-          name: 'sandbox',
-          owner: { login: 'int128' },
-          default_branch: 'main',
-        },
-      },
-    },
-    inputs
-  )
+  const c = cache.infer(eventPushTag, inputs)
   expect(c).toStrictEqual({
     from: ['ghcr.io/int128/sandbox/cache:main'],
     to: null,
@@ -106,52 +109,29 @@ test('on push tag', () => {
 })
 
 test('on push tag with prefix', () => {
-  const c = cache.infer(
-    {
-      eventName: 'push',
-      ref: 'refs/tags/v1.0.0',
-      payload: {
-        repository: {
-          name: 'sandbox',
-          owner: { login: 'int128' },
-          default_branch: 'main',
-        },
-      },
-    },
-    inputsPrefixed
-  )
-  expect(c).toStrictEqual({
-    from: ['ghcr.io/int128/sandbox/cache:prefix-main', 'ghcr.io/int128/sandbox/cache:main'],
-    to: null,
-  })
-})
-
-test('on schedule', () => {
-  const c = cache.infer(
-    {
-      eventName: 'schedule',
-      ref: 'refs/heads/main',
-      payload: {},
-    },
-    inputs
-  )
+  const c = cache.infer(eventPushTag, inputsPrefixed)
   expect(c).toStrictEqual({
     from: ['ghcr.io/int128/sandbox/cache:main'],
     to: null,
   })
 })
 
-test('on schedule with prefix', () => {
-  const c = cache.infer(
-    {
-      eventName: 'schedule',
-      ref: 'refs/heads/main',
-      payload: {},
-    },
-    inputsPrefixed
-  )
+test('on schedule', () => {
+  const c = cache.infer(eventSchedule, inputs)
   expect(c).toStrictEqual({
-    from: ['ghcr.io/int128/sandbox/cache:prefix-main', 'ghcr.io/int128/sandbox/cache:main'],
+    from: ['ghcr.io/int128/sandbox/cache:schedule', 'ghcr.io/int128/sandbox/cache:main'],
+    to: null,
+  })
+})
+
+test('on schedule with prefix', () => {
+  const c = cache.infer(eventSchedule, inputsPrefixed)
+  expect(c).toStrictEqual({
+    from: [
+      'ghcr.io/int128/sandbox/cache:prefix-schedule',
+      'ghcr.io/int128/sandbox/cache:schedule',
+      'ghcr.io/int128/sandbox/cache:main',
+    ],
     to: null,
   })
 })

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -41,6 +41,14 @@ const eventPushTag = {
   },
 }
 
+const eventReleaseTag = {
+  eventName: 'release',
+  ref: 'refs/tags/v1.0.0',
+  payload: {
+    ...payloadRepository,
+  },
+}
+
 const eventSchedule = {
   eventName: 'schedule',
   ref: 'refs/heads/schedule',
@@ -115,6 +123,26 @@ test('on push tag', () => {
 
 test('on push tag with prefix', () => {
   const c = cache.infer(eventPushTag, inputsPrefixed)
+  expect(c).toStrictEqual({
+    from: [
+      'ghcr.io/int128/sandbox/cache:prefix-main',
+      'ghcr.io/int128/sandbox/cache:prefix-b-main',
+      'ghcr.io/int128/sandbox/cache:main',
+    ],
+    to: [],
+  })
+})
+
+test('on release tag', () => {
+  const c = cache.infer(eventReleaseTag, inputs)
+  expect(c).toStrictEqual({
+    from: ['ghcr.io/int128/sandbox/cache:main'],
+    to: [],
+  })
+})
+
+test('on release tag with prefix', () => {
+  const c = cache.infer(eventReleaseTag, inputsPrefixed)
   expect(c).toStrictEqual({
     from: [
       'ghcr.io/int128/sandbox/cache:prefix-main',

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -97,6 +97,8 @@ test('on push branch with prefix', () => {
       'ghcr.io/int128/sandbox/cache:prefix-feature',
       'ghcr.io/int128/sandbox/cache:prefix-b-feature',
       'ghcr.io/int128/sandbox/cache:feature',
+      'ghcr.io/int128/sandbox/cache:prefix-main',
+      'ghcr.io/int128/sandbox/cache:prefix-b-main',
       'ghcr.io/int128/sandbox/cache:main',
     ],
     to: ['ghcr.io/int128/sandbox/cache:prefix-feature'],
@@ -114,7 +116,11 @@ test('on push tag', () => {
 test('on push tag with prefix', () => {
   const c = cache.infer(eventPushTag, inputsPrefixed)
   expect(c).toStrictEqual({
-    from: ['ghcr.io/int128/sandbox/cache:main'],
+    from: [
+      'ghcr.io/int128/sandbox/cache:prefix-main',
+      'ghcr.io/int128/sandbox/cache:prefix-b-main',
+      'ghcr.io/int128/sandbox/cache:main',
+    ],
     to: [],
   })
 })
@@ -134,6 +140,8 @@ test('on schedule with prefix', () => {
       'ghcr.io/int128/sandbox/cache:prefix-schedule',
       'ghcr.io/int128/sandbox/cache:prefix-b-schedule',
       'ghcr.io/int128/sandbox/cache:schedule',
+      'ghcr.io/int128/sandbox/cache:prefix-main',
+      'ghcr.io/int128/sandbox/cache:prefix-b-main',
       'ghcr.io/int128/sandbox/cache:main',
     ],
     to: [],

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,5 +1,15 @@
 import * as cache from '../src/cache'
 
+const inputs = {
+  image: 'ghcr.io/int128/sandbox/cache',
+  tagPrefix: '',
+}
+
+const inputsPrefixed = {
+  image: 'ghcr.io/int128/sandbox/cache',
+  tagPrefix: 'prefix-',
+}
+
 test('on pull request', () => {
   const c = cache.infer(
     {
@@ -14,13 +24,32 @@ test('on pull request', () => {
         },
       },
     },
-    {
-      image: 'ghcr.io/int128/sandbox/cache',
-      tagPrefix: '',
-    }
+    inputs
   )
   expect(c).toStrictEqual({
-    from: 'ghcr.io/int128/sandbox/cache:main',
+    from: ['ghcr.io/int128/sandbox/cache:main'],
+    to: null,
+  })
+})
+
+test('on pull request with prefix', () => {
+  const c = cache.infer(
+    {
+      eventName: 'pull_request',
+      ref: 'refs/pulls/123/merge',
+      payload: {
+        pull_request: {
+          number: 123,
+          base: {
+            ref: 'main',
+          },
+        },
+      },
+    },
+    inputsPrefixed
+  )
+  expect(c).toStrictEqual({
+    from: ['ghcr.io/int128/sandbox/cache:prefix-main', 'ghcr.io/int128/sandbox/cache:main'],
     to: null,
   })
 })
@@ -32,14 +61,26 @@ test('on push branch', () => {
       ref: 'refs/heads/main',
       payload: {},
     },
-    {
-      image: 'ghcr.io/int128/sandbox/cache',
-      tagPrefix: '',
-    }
+    inputs
   )
   expect(c).toStrictEqual({
-    from: 'ghcr.io/int128/sandbox/cache:main',
+    from: ['ghcr.io/int128/sandbox/cache:main'],
     to: 'ghcr.io/int128/sandbox/cache:main',
+  })
+})
+
+test('on push branch with prefix', () => {
+  const c = cache.infer(
+    {
+      eventName: 'push',
+      ref: 'refs/heads/main',
+      payload: {},
+    },
+    inputsPrefixed
+  )
+  expect(c).toStrictEqual({
+    from: ['ghcr.io/int128/sandbox/cache:prefix-main', 'ghcr.io/int128/sandbox/cache:main'],
+    to: 'ghcr.io/int128/sandbox/cache:prefix-main',
   })
 })
 
@@ -56,13 +97,31 @@ test('on push tag', () => {
         },
       },
     },
-    {
-      image: 'ghcr.io/int128/sandbox/cache',
-      tagPrefix: '',
-    }
+    inputs
   )
   expect(c).toStrictEqual({
-    from: 'ghcr.io/int128/sandbox/cache:main',
+    from: ['ghcr.io/int128/sandbox/cache:main'],
+    to: null,
+  })
+})
+
+test('on push tag with prefix', () => {
+  const c = cache.infer(
+    {
+      eventName: 'push',
+      ref: 'refs/tags/v1.0.0',
+      payload: {
+        repository: {
+          name: 'sandbox',
+          owner: { login: 'int128' },
+          default_branch: 'main',
+        },
+      },
+    },
+    inputsPrefixed
+  )
+  expect(c).toStrictEqual({
+    from: ['ghcr.io/int128/sandbox/cache:prefix-main', 'ghcr.io/int128/sandbox/cache:main'],
     to: null,
   })
 })
@@ -74,13 +133,25 @@ test('on schedule', () => {
       ref: 'refs/heads/main',
       payload: {},
     },
-    {
-      image: 'ghcr.io/int128/sandbox/cache',
-      tagPrefix: '',
-    }
+    inputs
   )
   expect(c).toStrictEqual({
-    from: 'ghcr.io/int128/sandbox/cache:main',
+    from: ['ghcr.io/int128/sandbox/cache:main'],
+    to: null,
+  })
+})
+
+test('on schedule with prefix', () => {
+  const c = cache.infer(
+    {
+      eventName: 'schedule',
+      ref: 'refs/heads/main',
+      payload: {},
+    },
+    inputsPrefixed
+  )
+  expect(c).toStrictEqual({
+    from: ['ghcr.io/int128/sandbox/cache:prefix-main', 'ghcr.io/int128/sandbox/cache:main'],
     to: null,
   })
 })

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -51,19 +51,19 @@ const eventSchedule = {
 
 const inputs = {
   image: 'ghcr.io/int128/sandbox/cache',
-  tagPrefix: '',
+  tagPrefix: [],
 }
 
 const inputsPrefixed = {
   image: 'ghcr.io/int128/sandbox/cache',
-  tagPrefix: 'prefix-',
+  tagPrefix: ['prefix-', 'prefix-b-'],
 }
 
 test('on pull request', () => {
   const c = cache.infer(eventPullRequest, inputs)
   expect(c).toStrictEqual({
     from: ['ghcr.io/int128/sandbox/cache:feature', 'ghcr.io/int128/sandbox/cache:main'],
-    to: null,
+    to: [],
   })
 })
 
@@ -73,10 +73,12 @@ test('on pull request with prefix', () => {
     from: [
       'ghcr.io/int128/sandbox/cache:prefix-feature',
       'ghcr.io/int128/sandbox/cache:prefix-main',
+      'ghcr.io/int128/sandbox/cache:prefix-b-feature',
+      'ghcr.io/int128/sandbox/cache:prefix-b-main',
       'ghcr.io/int128/sandbox/cache:feature',
       'ghcr.io/int128/sandbox/cache:main',
     ],
-    to: null,
+    to: [],
   })
 })
 
@@ -84,7 +86,7 @@ test('on push branch', () => {
   const c = cache.infer(eventPushBranch, inputs)
   expect(c).toStrictEqual({
     from: ['ghcr.io/int128/sandbox/cache:feature', 'ghcr.io/int128/sandbox/cache:main'],
-    to: 'ghcr.io/int128/sandbox/cache:feature',
+    to: ['ghcr.io/int128/sandbox/cache:feature'],
   })
 })
 
@@ -93,10 +95,11 @@ test('on push branch with prefix', () => {
   expect(c).toStrictEqual({
     from: [
       'ghcr.io/int128/sandbox/cache:prefix-feature',
+      'ghcr.io/int128/sandbox/cache:prefix-b-feature',
       'ghcr.io/int128/sandbox/cache:feature',
       'ghcr.io/int128/sandbox/cache:main',
     ],
-    to: 'ghcr.io/int128/sandbox/cache:prefix-feature',
+    to: ['ghcr.io/int128/sandbox/cache:prefix-feature'],
   })
 })
 
@@ -104,7 +107,7 @@ test('on push tag', () => {
   const c = cache.infer(eventPushTag, inputs)
   expect(c).toStrictEqual({
     from: ['ghcr.io/int128/sandbox/cache:main'],
-    to: null,
+    to: [],
   })
 })
 
@@ -112,7 +115,7 @@ test('on push tag with prefix', () => {
   const c = cache.infer(eventPushTag, inputsPrefixed)
   expect(c).toStrictEqual({
     from: ['ghcr.io/int128/sandbox/cache:main'],
-    to: null,
+    to: [],
   })
 })
 
@@ -120,7 +123,7 @@ test('on schedule', () => {
   const c = cache.infer(eventSchedule, inputs)
   expect(c).toStrictEqual({
     from: ['ghcr.io/int128/sandbox/cache:schedule', 'ghcr.io/int128/sandbox/cache:main'],
-    to: null,
+    to: [],
   })
 })
 
@@ -129,9 +132,10 @@ test('on schedule with prefix', () => {
   expect(c).toStrictEqual({
     from: [
       'ghcr.io/int128/sandbox/cache:prefix-schedule',
+      'ghcr.io/int128/sandbox/cache:prefix-b-schedule',
       'ghcr.io/int128/sandbox/cache:schedule',
       'ghcr.io/int128/sandbox/cache:main',
     ],
-    to: null,
+    to: [],
   })
 })


### PR DESCRIPTION
This PR allows to get the most specific cache available with fallback to all less specific ones. Also, it allows to use multiple prefixes.

For example a PR would first try the PR's branch cache, then the base branch cache, then the default branch cache.

For multiple prefixes only the first is used as output. The others allow for the import of caches from other build steps.

Imagine a "prepare" step in your build pipeline. This would export a "prepare" cache. The "next" step, which would need to run "prepare" itself a second time can then try to import "next", which would fail on the first run, then fallback to "prepare", which would then be available.