### PR TITLE
feat: add pull request cache behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ cache-from: type=registry,ref=IMAGE:main
 cache-to:
 ```
 
-#### When `pull_request_cache` input is set
+#### Import and export a pull request cache
 
-When `pull_request_cache` input is set, this action instructs docker/build-push-action to import and export cache of the pull request.
+When `pull-request-cache` input is set, this action instructs docker/build-push-action to import and export cache of the pull request.
 
 ```yaml
 cache-from: |
@@ -61,7 +61,9 @@ cache-to: type=registry,ref=IMAGE:pr-1,mode=max
 ```
 
 This is useful when you want to improve build cache between consecutive commits for a same pull request.
-Note: that it will create a tag for every pull request, we recommand to clean it when pull request is closed
+
+Note that it will create an image tag for every pull request.
+It is recommended to clean it when pull request is closed, or set a lifecycle policy in your container repository.
 
 ### `push` event of branch
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ cache-from: type=registry,ref=IMAGE:main
 cache-to:
 ```
 
+#### When `pull_request_cache` input is set
+
+When `pull_request_cache` input is set, this action instructs docker/build-push-action to import and export cache of the pull request.
+
+```yaml
+cache-from: |
+  type=registry,ref=IMAGE:pr-1
+  type=registry,ref=IMAGE:main
+cache-to: type=registry,ref=IMAGE:pr-1,mode=max
+```
+
+This is useful when you want to improve build cache between consecutive commits for a same pull request.
+Note: that it will create a tag for every pull request, we recommand to clean it when pull request is closed
+
 ### `push` event of branch
 
 When a branch is pushed, this action instructs docker/build-push-action to import and export cache of the branch.
@@ -208,14 +222,15 @@ jobs:
 
 ### Inputs
 
-| Name               | Default    | Description                         |
-| ------------------ | ---------- | ----------------------------------- |
-| `image`            | (required) | Image name to import/export cache   |
-| `flavor`           | ` `        | Flavor in form of `prefix=,suffix=` |
-| `tag-prefix`       | ` `        | Prefix of tag (deprecated)          |
-| `tag-suffix`       | ` `        | Suffix of tag (deprecated)          |
-| `extra-cache-from` | ` `        | Extra flag to `cache-from`          |
-| `extra-cache-to`   | ` `        | Extra flag to `cache-to`            |
+| Name                 | Default    | Description                                 |
+| -------------------- | ---------- | ------------------------------------------- |
+| `image`              | (required) | Image name to import/export cache           |
+| `flavor`             | ` `        | Flavor in form of `prefix=,suffix=`         |
+| `tag-prefix`         | ` `        | Prefix of tag (deprecated)                  |
+| `tag-suffix`         | ` `        | Suffix of tag (deprecated)                  |
+| `extra-cache-from`   | ` `        | Extra flag to `cache-from`                  |
+| `extra-cache-to`     | ` `        | Extra flag to `cache-to`                    |
+| `pull-request-cache` | ``         | Flag to enable Pull request dedicated cache |
 
 `flavor` is mostly compatible with [docker/metadata-action](https://github.com/docker/metadata-action#flavor-input)
 except this action supports only `prefix` and `suffix`.

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,7 @@ inputs:
   pull-request-cache:
     description: flag to enable Pull request dedicated cache
     required: false
+    default: 'false'
 
 outputs:
   cache-from:

--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,9 @@ inputs:
     description: token to access github api
     required: false
     default: ${{ github.token }}
+  pull-request-cache:
+    description: flag to enable Pull request dedicated cache
+    required: false
 
 outputs:
   cache-from:

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,6 +1,6 @@
 type Inputs = {
-  cacheFromImageTag: string
-  cacheToImageTag: string | null
+  cacheFromImageTag: string[]
+  cacheToImageTag: string[]
   extraCacheFrom: string
   extraCacheTo: string
 }
@@ -11,21 +11,25 @@ type Outputs = {
 }
 
 export const generateDockerFlags = (inputs: Inputs): Outputs => {
-  const cacheFrom = ['type=registry', `ref=${inputs.cacheFromImageTag}`]
-  if (inputs.extraCacheFrom) {
-    cacheFrom.push(inputs.extraCacheFrom)
-  }
+  const cacheFrom = inputs.cacheFromImageTag.map((tag) => {
+    const cacheFrom = ['type=registry', `ref=${tag}`]
+    if (inputs.extraCacheFrom) {
+      cacheFrom.push(inputs.extraCacheFrom)
+    }
+    return cacheFrom.join(',')
+  })
 
-  const cacheTo = []
-  if (inputs.cacheToImageTag) {
-    cacheTo.push('type=registry', `ref=${inputs.cacheToImageTag}`, 'mode=max')
+  const cacheTo = inputs.cacheToImageTag.map((tag) => {
+    const cacheTo = []
+    cacheTo.push('type=registry', `ref=${tag}`, 'mode=max')
     if (inputs.extraCacheTo) {
       cacheTo.push(inputs.extraCacheTo)
     }
-  }
+    return cacheTo.join(',')
+  })
 
   return {
-    cacheFrom: cacheFrom.join(','),
-    cacheTo: cacheTo.join(','),
+    cacheFrom: cacheFrom.join('\n'),
+    cacheTo: cacheTo.join('\n'),
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ const main = async (): Promise<void> => {
     tagSuffix: core.getInput('tag-suffix'),
     extraCacheFrom: core.getInput('extra-cache-from'),
     extraCacheTo: core.getInput('extra-cache-to'),
-    pullRequestCache: core.getInput('pull-request-cache') === 'true',
+    pullRequestCache: core.getBooleanInput('pull-request-cache'),
     token: core.getInput('token', { required: true }),
   })
   core.info(`Setting outputs: ${JSON.stringify(outputs, undefined, 2)}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ const main = async (): Promise<void> => {
     tagSuffix: core.getInput('tag-suffix'),
     extraCacheFrom: core.getInput('extra-cache-from'),
     extraCacheTo: core.getInput('extra-cache-to'),
+    pullRequestCache: core.getInput('pull-request-cache') === 'true',
     token: core.getInput('token', { required: true }),
   })
   core.info(`Setting outputs: ${JSON.stringify(outputs, undefined, 2)}`)

--- a/src/run.ts
+++ b/src/run.ts
@@ -11,6 +11,7 @@ type Inputs = {
   token: string
   extraCacheFrom: string
   extraCacheTo: string
+  pullRequestCache: boolean
 }
 
 type Outputs = {
@@ -20,8 +21,8 @@ type Outputs = {
 
 export const run = async (inputs: Inputs): Promise<Outputs> => {
   const c = await inferImageTags(github.context, inputs)
-  core.info(`Inferred image tag of from: ${c.from}`)
-  core.info(`Inferred image tag of to: ${c.to}`)
+  core.info(`Inferred image tag of from: ${c.from.join(', ')}`)
+  core.info(`Inferred image tag of to: ${c.to.join(', ')}`)
   return generateDockerFlags({
     cacheFromImageTag: c.from,
     cacheToImageTag: c.to,

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -2,8 +2,8 @@ import { generateDockerFlags } from '../src/docker'
 
 test('both from and to', () => {
   const outputs = generateDockerFlags({
-    cacheFromImageTag: 'ghcr.io/int128/sandbox/cache:main',
-    cacheToImageTag: 'ghcr.io/int128/sandbox/cache:main',
+    cacheFromImageTag: ['ghcr.io/int128/sandbox/cache:main'],
+    cacheToImageTag: ['ghcr.io/int128/sandbox/cache:main'],
     extraCacheFrom: '',
     extraCacheTo: '',
   })
@@ -15,8 +15,8 @@ test('both from and to', () => {
 
 test('only from', () => {
   const outputs = generateDockerFlags({
-    cacheFromImageTag: 'ghcr.io/int128/sandbox/cache:main',
-    cacheToImageTag: null,
+    cacheFromImageTag: ['ghcr.io/int128/sandbox/cache:main'],
+    cacheToImageTag: [],
     extraCacheFrom: '',
     extraCacheTo: '',
   })
@@ -28,8 +28,8 @@ test('only from', () => {
 
 test('both from and to with extra args', () => {
   const outputs = generateDockerFlags({
-    cacheFromImageTag: 'ghcr.io/int128/sandbox/cache:main',
-    cacheToImageTag: 'ghcr.io/int128/sandbox/cache:main',
+    cacheFromImageTag: ['ghcr.io/int128/sandbox/cache:main'],
+    cacheToImageTag: ['ghcr.io/int128/sandbox/cache:main'],
     extraCacheFrom: 'foo=bar',
     extraCacheTo: 'image-manifest=true',
   })
@@ -41,13 +41,29 @@ test('both from and to with extra args', () => {
 
 test('only from with extra args', () => {
   const outputs = generateDockerFlags({
-    cacheFromImageTag: 'ghcr.io/int128/sandbox/cache:main',
-    cacheToImageTag: null,
+    cacheFromImageTag: ['ghcr.io/int128/sandbox/cache:main'],
+    cacheToImageTag: [],
     extraCacheFrom: 'foo=bar',
     extraCacheTo: 'image-manifest=true',
   })
   expect(outputs).toStrictEqual({
     cacheFrom: 'type=registry,ref=ghcr.io/int128/sandbox/cache:main,foo=bar',
     cacheTo: '',
+  })
+})
+
+test('both multiple from and to', () => {
+  const outputs = generateDockerFlags({
+    cacheFromImageTag: ['ghcr.io/int128/sandbox/cache:pr-1', 'ghcr.io/int128/sandbox/cache:main'],
+    cacheToImageTag: ['ghcr.io/int128/sandbox/cache:pr-1'],
+    extraCacheFrom: '',
+    extraCacheTo: '',
+  })
+  expect(outputs).toStrictEqual({
+    cacheFrom:
+      'type=registry,ref=ghcr.io/int128/sandbox/cache:pr-1' +
+      '\n' +
+      'type=registry,ref=ghcr.io/int128/sandbox/cache:main',
+    cacheTo: 'type=registry,ref=ghcr.io/int128/sandbox/cache:pr-1,mode=max',
   })
 })


### PR DESCRIPTION
When `pull_request_cache` input is set, this action instructs docker/build-push-action to import and export cache of the pull request.

```yaml
cache-from: |
  type=registry,ref=IMAGE:pr-1
  type=registry,ref=IMAGE:main
cache-to: type=registry,ref=IMAGE:pr-1,mode=max
```

This is useful when you want to improve build cache between consecutive commits for a same pull request.