### PR TITLE
fix(docker): use `scope` instead of `ref` for GHA cache backend

### DIFF
--- a/src/docker.ts
+++ b/src/docker.ts
@@ -15,9 +15,10 @@ export type DockerFlags = {
 
 export const generateDockerFlags = (inputs: Inputs): DockerFlags => {
   const cacheType = `type=${inputs.cacheType}`
+  const refKey = inputs.cacheType === 'gha' ? 'scope' : 'ref'
 
   const cacheFrom = inputs.cacheFromImageTag.map((tag) => {
-    const cacheFrom = [cacheType, `ref=${tag}`]
+    const cacheFrom = [cacheType, `${refKey}=${tag}`]
     if (inputs.extraCacheFrom) {
       cacheFrom.push(inputs.extraCacheFrom)
     }
@@ -26,7 +27,7 @@ export const generateDockerFlags = (inputs: Inputs): DockerFlags => {
 
   const cacheTo = inputs.cacheToImageTag.map((tag) => {
     const cacheTo = []
-    cacheTo.push(cacheType, `ref=${tag}`, 'mode=max')
+    cacheTo.push(cacheType, `${refKey}=${tag}`, 'mode=max')
     if (inputs.extraCacheTo) {
       cacheTo.push(inputs.extraCacheTo)
     }

--- a/tests/docker.test.ts
+++ b/tests/docker.test.ts
@@ -83,7 +83,7 @@ test('cache type', () => {
     extraCacheTo: '',
   })
   expect(outputs).toStrictEqual({
-    cacheFrom: ['type=gha,ref=ghcr.io/int128/sandbox/cache:pr-1', 'type=gha,ref=ghcr.io/int128/sandbox/cache:main'],
-    cacheTo: ['type=gha,ref=ghcr.io/int128/sandbox/cache:pr-1,mode=max'],
+    cacheFrom: ['type=gha,scope=ghcr.io/int128/sandbox/cache:pr-1', 'type=gha,scope=ghcr.io/int128/sandbox/cache:main'],
+    cacheTo: ['type=gha,scope=ghcr.io/int128/sandbox/cache:pr-1,mode=max'],
   })
 })


### PR DESCRIPTION
This pull request updates the `generateDockerFlags` function and its associated tests to dynamically determine the correct key (`scope` or `ref`) for Docker cache flags based on the `cacheType` input. This improves flexibility and ensures compatibility with different cache types.

### Updates to `generateDockerFlags` function:

* Modified the `generateDockerFlags` function in `src/docker.ts` to use a dynamic key (`refKey`) for cache flags, which is set to `scope` if `cacheType` is `gha`, and `ref` otherwise. This change affects both `cacheFrom` and `cacheTo` flag generation. [[1]](diffhunk://#diff-09d96be3c3071d65f09426089805f2cd771f2b44698ddd3ee9bc0656f8f30422R18-R21) [[2]](diffhunk://#diff-09d96be3c3071d65f09426089805f2cd771f2b44698ddd3ee9bc0656f8f30422L29-R30)

### Updates to tests:

* Updated the unit test in `tests/docker.test.ts` to reflect the new behavior of the `generateDockerFlags` function, verifying that the correct key (`scope` or `ref`) is used in the generated cache flags.

## Context
When using the GitHub Actions (GHA) cache backend, the use of useless tags `ref=` leads to cache collisions between different builds, branches, and stages due to the shared default namespace (buildkit).

This change replaces `ref=` with `scope=` when the cache type is `gha`, as recommended by the official Docker documentation: https://docs.docker.com/build/cache/backends/gha/#scope

Using `scope=` ensures proper cache isolation and prevents unintended invalidation, significantly improving cache reliability.

